### PR TITLE
fix(Upgrade): Cleaner way to deal with ignored parameters {100%}

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -984,8 +984,11 @@ class PEP257Checker(object):
         # Emptry string is for when there are no params.
         IGNORED_PARAMETERS = ["self", "request", "*args", "**kwargs", ""]
 
+        # Just drop all ignored parameters. This is a lot cleaner.
+        params = list(set(params) - set(IGNORED_PARAMETERS))
+
         # Ignore self if it is the only param
-        if len(params) == 1 and params[0] in IGNORED_PARAMETERS:
+        if len(params) == 0:
             return
 
         if len(params) > 0:


### PR DESCRIPTION
**Status: 100%**

@jkeesh @zgalant 

Should be the last fix. I cleaned up how we check for ignored parameters. Now we just take the difference of the sets. The reason is because it wouldn't catch the edge case where your parameters were `*args, **kwargs`.
