### PR TITLE
fix(Upgrade): Now supports multiline function defs [100%]

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -974,10 +974,10 @@ class PEP257Checker(object):
 
         # In case of multline function definition with long parameters, we need
         # to reconstruct the definition from source.
-        functions_source = function.source.split("\n")
+        function_source = function.source.split("\n")
         function_def = ''
         while not function_def.endswith(":"):
-            function_def += functions_source.pop(0)
+            function_def += function_source.pop(0)
         function_def = function_def.strip()
         ___split = function_def.split("(")
         ___name = ___split[0].split()[1]

--- a/pep257.py
+++ b/pep257.py
@@ -1012,8 +1012,6 @@ class PEP257Checker(object):
             #    description
             reg = escape(p) + ': \w+\n\s+\w+'
             if not re(reg).search(docstring):
-                # print function.source
-                print params
                 print "[Method %s] Forgot to document parameter %s" % (
                     ___name, p)
                 ___fail = True


### PR DESCRIPTION
**Status: 100%**
_Review requested_

@zgalant 

Currently, the linter will have issues handling function declarations of this form:

```
def classset_progress_dashboard(request, classset_id, course_id, page_type,
                                progress_type):
```

I've now added support for it.
